### PR TITLE
Correct bitmask/bool mixup for STM32 probe pin

### DIFF
--- a/drivers/STM32F1xx/Src/driver.c
+++ b/drivers/STM32F1xx/Src/driver.c
@@ -368,10 +368,10 @@ static control_signals_t systemGetState (void)
 // and the probing cycle modes for toward-workpiece/away-from-workpiece.
 static void probeConfigure(bool is_probe_away, bool probing)
 {
-    probe_invert = settings.probe.invert_probe_pin;
+    probe_invert = settings.probe.invert_probe_pin ? 1 : 0;
 
     if (is_probe_away)
-        probe_invert ^= PROBE_BIT;
+        probe_invert ^= 1;
 }
 
 // Returns the probe connected and triggered pin states.

--- a/drivers/STM32F4xx/Src/driver.c
+++ b/drivers/STM32F4xx/Src/driver.c
@@ -554,10 +554,10 @@ static control_signals_t systemGetState (void)
 // and the probing cycle modes for toward-workpiece/away-from-workpiece.
 static void probeConfigure(bool is_probe_away, bool probing)
 {
-    probe_invert = settings.probe.invert_probe_pin;
+    probe_invert = settings.probe.invert_probe_pin ? 1 : 0;
 #ifdef PROBE_PIN
     if (is_probe_away)
-        probe_invert ^= PROBE_BIT;
+        probe_invert ^= 1;
 #endif
 }
 


### PR DESCRIPTION
probe_invert is a bool value. Trying to invert its value by xor'ing with
a bitmask is prone to fail (dependent on the actual value of the
PROBE_BIT bitmask).

Fixes non-working tool change operations with e.g. bCNC (which always
uses both G38.2 and G38.4).