### PR TITLE
added STM32F407 info in driver.c

### DIFF
--- a/drivers/STM32F4xx/Src/driver.c
+++ b/drivers/STM32F4xx/Src/driver.c
@@ -1374,6 +1374,8 @@ bool driver_init (void)
     hal.info = "STM32F446";
 #elif defined(STM32F411xE)
     hal.info = "STM32F411";
+#elif defined(STM32F407xx)
+    hal.info = "STM32F407";
 #else
     hal.info = "STM32F401CC";
 #endif


### PR DESCRIPTION
Hello, I added the STMF32F407 hal.info so that the $I command reports the correct CPU.