### PR TITLE
SerialUSB needs to be called, not Serial

### DIFF
--- a/drivers/SAMD21/grblHAL_MKRZERO/src/usb_serial.cpp
+++ b/drivers/SAMD21/grblHAL_MKRZERO/src/usb_serial.cpp
@@ -121,11 +121,11 @@ void usb_serialWriteS (const char *s)
 
             while(txbuf.length) {
 
-                if((avail = Serial.availableForWrite()) > 10) {
+                if((avail = SerialUSB.availableForWrite()) > 10) {
 
                     length = avail < txbuf.length ? avail : txbuf.length;
 
-                    Serial.write((uint8_t *)txbuf.s, length); // doc is wrong - does not return bytes sent!
+                    SerialUSB.write((uint8_t *)txbuf.s, length); // doc is wrong - does not return bytes sent!
 
                     txbuf.length -= length;
                     txbuf.s += length;


### PR DESCRIPTION
I do not have an actual Arduino Zero to test. I have a SAMD21J18A. I built the SAMD21 driver but could not get a response via SerialUSB. Debugging showed it was receiving. Made this change to solve issue. 