### PR TITLE
STM32 modbus fix

### DIFF
--- a/drivers/STM32F4xx/Src/serial.c
+++ b/drivers/STM32F4xx/Src/serial.c
@@ -306,8 +306,6 @@ bool serial2SetBaudRate (uint32_t baud_rate)
         init_ok = true;
     }
 
-    UART2->BRR = UART_BRR_SAMPLING16(HAL_RCC_GetPCLK1Freq(), baud_rate);
-
     return true;
 }
 


### PR DESCRIPTION
Attempts to use the wrong clock source when setting the baud rate for USART1,
is not needed as the baud rate is already set correctly inside serial2Init.